### PR TITLE
購入完了画面の追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -64,7 +64,7 @@ class ItemsController < ApplicationController
       @item.destination_id = params[:destination_id]
       @item.status = 2
       @item.save
-      redirect_to complete_item_path, notice: "商品は正常に購入されました"
+      redirect_to complete_item_path
       return
     rescue => error
       p error

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -61,8 +61,10 @@ class ItemsController < ApplicationController
       @item.closed_time = Time.now
       @item.buyer_id = current_user.id
       @item.destination_id = params[:destination_id]
+      @item.status = 2
       @item.save
-      redirect_to root_path, notice: "商品は正常に購入されました"
+      binding.pry
+      redirect_to complete_item_path, notice: "商品は正常に購入されました"
     rescue => error
       p error
       redirect_to confirm_item_path, alert: "購入できませんでした。再度お試しください"

--- a/app/views/items/complete.html.haml
+++ b/app/views/items/complete.html.haml
@@ -1,0 +1,17 @@
+.single-container
+  %header.single-header
+    %h1.single-header__logo
+      = link_to root_path do
+        = image_tag("logo.png",size: "189x49",class: "image")
+
+  .single-main
+    %h2.single-main__head 購入完了
+    .single-main__form
+      .single-main__content
+        .form-group
+          商品は正常に購入されました。
+        .form-group
+          %p.form-group__text--center
+          %button{type:"button",class: "btn-default btn-red",onclick: "location.href='/'"}トップページに移動
+
+  = render "devise/registrations/registration_footer"

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -3,6 +3,14 @@
     .header__logo
       = link_to root_path,class: 'header__logo--link' do
         = image_tag "logo.png",class:"header__logo--img"
+  :javascript
+    function check(){
+      if(window.confirm("購入を確定します。よろしいですか？")){
+        return true;
+      }else{
+        return false;
+      }
+    }
   .confirm-main
     .confirm-main_title
       購入内容の確認
@@ -19,7 +27,7 @@
           円
 
     .confirm-main_form
-      %form{action:purchase_item_path,method:"POST",name:"purchase"}
+      %form{action:purchase_item_path,method:"POST",name:"purchase",onsubmit:"return check()"}
         %input{type:"hidden",name:"payjp_customer_id",value:@customer[:id]}
         %input{type:"hidden",name:"authenticity_token",value:form_authenticity_token}
         .confirm-main_form-destination

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     member do
       get 'confirm'
       post 'purchase'
+      get 'complete'
     end
   end
 end


### PR DESCRIPTION
#  WHAT
- 購入が正常に完了した場合、完了したことを知らせるviewを追加した。
![d1bafd9be3cd6f72c04ab0810503a2e0](https://user-images.githubusercontent.com/62142890/88992098-6463dd00-d31d-11ea-9694-5259f8804f0b.gif)

# WHY
- 今まではflash messageを使用して購入完了を通知していたが、これではわかりにくいという声があったため